### PR TITLE
Implement configuration options to set dynamodb local download path

### DIFF
--- a/dynamodb/core.js
+++ b/dynamodb/core.js
@@ -32,7 +32,7 @@ let runningProcesses = {},
             return new BbPromise(function(resolve, reject) {
                 /* Dynamodb local documentation http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html */
                 let additionalArgs = [],
-                    downloadDirectory = options.downloadDirectory || DB_PATH;
+                    downloadFrom = options.downloadFrom || DB_PATH;
                 options.port = options.port || 8000;
 
                 if (options.dbPath) { 
@@ -55,14 +55,14 @@ let runningProcesses = {},
                 if (options.help) {
                     additionalArgs.push('-help');
                 }
-                installer.setup(downloadDirectory, DOWNLOAD_PATH, JAR, spinner)
+                installer.setup(downloadFrom, DOWNLOAD_PATH, JAR, spinner)
                     .then(function() {
                         let args = [
-                            '-Djava.library.path=' + downloadDirectory + '/DynamoDBLocal_lib', '-jar', JAR, '-port', options.port
+                            '-Djava.library.path=' + downloadFrom + '/DynamoDBLocal_lib', '-jar', JAR, '-port', options.port
                         ];
                         args = args.concat(additionalArgs);
                         let child = spawn('java', args, {
-                            cwd: downloadDirectory,
+                            cwd: downloadFrom,
                             env: process.env,
                             stdio: ['pipe', 'pipe', process.stderr]
                         });
@@ -83,7 +83,7 @@ let runningProcesses = {},
                         console.log('Started: Dynamodb local(pid=' + child.pid + ') ', 'via java', args.join(' '));
                         console.log('Visit: http://localhost:' + options.port + '/shell');
                         writeFile(DB_PATH + '/options.json', options).then(resolve, reject);
-                        writeFile(DB_PATH + '/path.json', downloadDirectory);
+                        writeFile(DB_PATH + '/path.json', downloadFrom);
                     });
             });
         },
@@ -98,9 +98,9 @@ let runningProcesses = {},
             this.start(port, db);
         },
         remove: function() {
-            let downloadedDirectory = JSON.parse(fs.readFileSync(DB_PATH + '/path.json', 'utf8'));
-            console.log("removing dynamodb from ", downloadedDirectory);
-            installer.remove(downloadedDirectory);
+            let downloadedFrom = JSON.parse(fs.readFileSync(DB_PATH + '/path.json', 'utf8'));
+            console.log("removing dynamodb from ", downloadedFrom);
+            installer.remove(downloadedFrom);
         }
     };
 

--- a/dynamodb/core.js
+++ b/dynamodb/core.js
@@ -11,9 +11,9 @@ const DOWNLOAD_PATH = 'http://dynamodb-local.s3-website-us-west-2.amazonaws.com/
     DB_PATH = path.dirname(__filename) + '/bin';
 
 let runningProcesses = {},
-    writeFile = function (name, data) {
-        return new BbPromise(function (resolve, reject) {
-            fs.writeFile(name, JSON.stringify(data, null, 4), function (err) {
+    writeFile = function(name, data) {
+        return new BbPromise(function(resolve, reject) {
+            fs.writeFile(name, JSON.stringify(data, null, 4), function(err) {
                 if (err) {
                     reject(err);
                 } else {
@@ -28,13 +28,14 @@ let runningProcesses = {},
          * @param options
          * @returns {Promise.<ChildProcess>}
          */
-        start: function (options, spinner) {
-            return new BbPromise(function (resolve, reject) {
+        start: function(options, spinner) {
+            return new BbPromise(function(resolve, reject) {
                 /* Dynamodb local documentation http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html */
-                let additionalArgs = [];
+                let additionalArgs = [],
+                    downloadDirectory = options.downloadDirectory || DB_PATH;
                 options.port = options.port || 8000;
 
-                if (options.dbPath) { //
+                if (options.dbPath) { 
                     additionalArgs.push('-dbPath', options.dbPath);
                 } else {
                     additionalArgs.push('-inMemory');
@@ -54,14 +55,14 @@ let runningProcesses = {},
                 if (options.help) {
                     additionalArgs.push('-help');
                 }
-				installer.setup(DB_PATH, DOWNLOAD_PATH, JAR, spinner)
-                    .then(function () {
+                installer.setup(downloadDirectory, DOWNLOAD_PATH, JAR, spinner)
+                    .then(function() {
                         let args = [
-                        '-Djava.library.path=./DynamoDBLocal_lib', '-jar', JAR, '-port', options.port
-                    ];
+                            '-Djava.library.path=' + downloadDirectory + '/DynamoDBLocal_lib', '-jar', JAR, '-port', options.port
+                        ];
                         args = args.concat(additionalArgs);
                         let child = spawn('java', args, {
-                            cwd: DB_PATH,
+                            cwd: downloadDirectory,
                             env: process.env,
                             stdio: ['pipe', 'pipe', process.stderr]
                         });
@@ -69,11 +70,11 @@ let runningProcesses = {},
                             throw new Error('Unable to start DynamoDB Local process!');
                         }
                         child
-                            .on('error', function (err) {
+                            .on('error', function(err) {
                                 console.log('DynamoDB local start error', err);
                                 throw new Error('DynamoDB Local failed to start!');
                             })
-                            .on('close', function (code) {
+                            .on('close', function(code) {
                                 if (code !== null && code !== 0) {
                                     console.log('DynamoDB Local failed to start with code', code);
                                 }
@@ -82,20 +83,25 @@ let runningProcesses = {},
                         console.log('Started: Dynamodb local(pid=' + child.pid + ') ', 'via java', args.join(' '));
                         console.log('Visit: http://localhost:' + options.port + '/shell');
                         writeFile(DB_PATH + '/options.json', options).then(resolve, reject);
+                        writeFile(DB_PATH + '/path.json', downloadDirectory);
                     });
             });
         },
-        stop: function (port) {
+        stop: function(port) {
             if (runningProcesses[port]) {
                 runningProcesses[port].kill('SIGKILL');
                 delete runningProcesses[port];
             }
         },
-        restart: function (port, db) {
+        restart: function(port, db) {
             this.stop(port);
             this.start(port, db);
         },
-        remove: installer.remove.bind(null, DB_PATH)
+        remove: function() {
+            let downloadedDirectory = JSON.parse(fs.readFileSync(DB_PATH + '/path.json', 'utf8'));
+            console.log("removing dynamodb from ", downloadedDirectory);
+            installer.remove(downloadedDirectory);
+        }
     };
 
 module.exports = dynamodb;

--- a/dynamodb/installer.js
+++ b/dynamodb/installer.js
@@ -6,10 +6,10 @@ let BbPromise = require('bluebird'),
     path = require('path'),
     http = require('http'),
     fs = require('fs');
-	
+    
 
 let download = function (source, destination, spinner) {
-	let createDir = function (path) {
+    let createDir = function (path) {
         if (!fs.existsSync(path)) {
             fs.mkdirSync(path);
         }
@@ -24,7 +24,7 @@ let download = function (source, destination, spinner) {
                         let len = parseInt(redirectResponse.headers['content-length'], 10),
                             cur = 0,
                             total = len / 1048576; //1048576 - bytes in 1Megabyte
-						console.log("Downloading dynamodb local (Size " + total.toFixed(2) + " mb). This is one-time operation and can take several minutes ...");
+                        console.log("Downloading dynamodb local (Size " + total.toFixed(2) + " mb). This is one-time operation and can take several minutes ...");
                         if (200 != redirectResponse.statusCode) {
                             reject(new Error('Error getting DynamoDb local latest tar.gz location ' + response.headers.location + ': ' + redirectResponse.statusCode));
                         }
@@ -34,7 +34,7 @@ let download = function (source, destination, spinner) {
                                 path: destination
                             }))
                             .on('end', function () {
-								spinner.stop(true);
+                                spinner.stop(true);
                                 console.log("Installation complete ...");
                                 resolve();
                             })
@@ -42,7 +42,7 @@ let download = function (source, destination, spinner) {
                                 reject(err);
                             }).on("data", function (chunk) {
                                 cur += chunk.length;
-								//process.stdout.write("Downloading " + (100.0 * cur / len).toFixed(2) + "% \r");
+                                //process.stdout.write("Downloading " + (100.0 * cur / len).toFixed(2) + "% \r");
                             });
                     })
                     .on('error', function (e) {
@@ -56,10 +56,10 @@ let download = function (source, destination, spinner) {
 };
 
 let setup = function (dbPath, downloadPath, jar, spinner) {
-	return new BbPromise(function (resolve, reject) {
+    return new BbPromise(function (resolve, reject) {
         try {
             if (fs.existsSync(path.join(dbPath, jar))) {
-				spinner.stop(true);
+                spinner.stop(true);
                 resolve(true);
             } else {
                 download(downloadPath, dbPath, spinner).then(resolve, reject);

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ const _ = require('lodash'),
     tables = require('./tables/core'),
     dynamodb = require('./dynamodb/core');
 
-module.exports = function (S) { // Always pass in the ServerlessPlugin Class
-	const SCli = require(S.getServerlessPath('utils/cli'));
+module.exports = function(S) { // Always pass in the ServerlessPlugin Class
+    const SCli = require(S.getServerlessPath('utils/cli'));
 
     class DynamodbLocal extends S.classes.Plugin {
 
@@ -33,11 +33,11 @@ module.exports = function (S) { // Always pass in the ServerlessPlugin Class
                     option: 'new',
                     shortcut: 'n',
                     description: 'Create a new table & seed template for the given table name, inside the directlry given in s-project.json.'
-        }, {
+                }, {
                     option: 'create',
                     shortcut: 'c',
                     description: 'Create dynamodb tables and run seeds'
-        }]
+                }]
             });
             S.addAction(this.remove.bind(this), {
                 handler: 'dynamodbRemove',
@@ -54,35 +54,39 @@ module.exports = function (S) { // Always pass in the ServerlessPlugin Class
                     option: 'port',
                     shortcut: 'p',
                     description: 'The port number that DynamoDB will use to communicate with your application. If you do not specify this option, the default port is 8000'
-        }, {
+                }, {
                     option: 'cors',
                     shortcut: 'r',
                     description: 'Enable CORS support (cross-origin resource sharing) for JavaScript. You must provide a comma-separated "allow" list of specific domains. The default setting for -cors is an asterisk (*), which allows public access.'
-        }, {
+                }, {
                     option: 'inMemory',
                     shortcut: 'm',
                     description: 'DynamoDB; will run in memory, instead of using a database file. When you stop DynamoDB;, none of the data will be saved. Note that you cannot specify both -dbPath and -inMemory at once.'
-        }, {
+                }, {
                     option: 'dbPath',
                     shortcut: 'd',
                     description: 'The directory where DynamoDB will write its database file. If you do not specify this option, the file will be written to the current directory. Note that you cannot specify both -dbPath and -inMemory at once. For the path, current working directory is <projectroot>/node_modules/serverless-dynamodb-local/dynamob. For example to create <projectroot>/node_modules/serverless-dynamodb-local/dynamob/<mypath> you should specify -d <mypath>/ or --dbPath <mypath>/ with a forwardslash at the end.'
-        }, {
+                }, {
                     option: 'sharedDb',
                     shortcut: 'h',
                     description: 'DynamoDB will use a single database file, instead of using separate files for each credential and region. If you specify -sharedDb, all DynamoDB clients will interact with the same set of tables regardless of their region and credential configuration.'
-        }, {
+                }, {
                     option: 'delayTransientStatuses',
                     shortcut: 't',
                     description: 'Causes DynamoDB to introduce delays for certain operations. DynamoDB can perform some tasks almost instantaneously, such as create/update/delete operations on tables and indexes; however, the actual DynamoDB service requires more time for these tasks. Setting this parameter helps DynamoDB simulate the behavior of the Amazon DynamoDB web service more closely. (Currently, this parameter introduces delays only for global secondary indexes that are in either CREATING or DELETING status.)'
-        }, {
+                }, {
                     option: 'optimizeDbBeforeStartup',
                     shortcut: 'o',
                     description: 'Optimizes the underlying database tables before starting up DynamoDB on your computer. You must also specify -dbPath when you use this parameter.'
-        }, {
+                }, {
                     option: 'create',
                     shortcut: 'c',
                     description: 'After starting dynamodb local, create dynamodb tables and run seeds'
-        }]
+                }, {
+                    option: 'downloadDirectory',
+                    shortcut: 'D',
+                    description: 'Specify the path where you want to download dynamodb. Default path is serverless-dynamodb-local/dynamodb/bin'
+                }]
             });
 
             return BbPromise.resolve();
@@ -101,7 +105,7 @@ module.exports = function (S) { // Always pass in the ServerlessPlugin Class
         }
 
         table(evt) {
-            return new BbPromise(function (resolve, reject) {
+            return new BbPromise(function(resolve, reject) {
                 let options = evt.options,
                     config = S.getProject().custom.dynamodb,
                     table = config && config.table || {},
@@ -123,7 +127,7 @@ module.exports = function (S) { // Always pass in the ServerlessPlugin Class
 
         start(evt) {
             let self = this;
-            return new BbPromise(function (resolve, reject) {
+            return new BbPromise(function(resolve, reject) {
                 let config = S.getProject().custom.dynamodb,
                     options = _.merge({
                             sharedDb: evt.options.sharedDb || true
@@ -131,14 +135,14 @@ module.exports = function (S) { // Always pass in the ServerlessPlugin Class
                         evt.options,
                         config && config.start
                     ),
-		    _spinner = SCli.spinner();;
+                    _spinner = SCli.spinner();
                 if (options.create) {
-                    dynamodb.start(options).then(function () {
+                    dynamodb.start(options).then(function() {
                         console.log(""); // seperator
                         self.table(evt).then(resolve, reject);
                     });
                 } else {
-		    _spinner.start()
+                    _spinner.start();
                     dynamodb.start(options, _spinner).then(resolve, reject);
                 }
             });

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
                     shortcut: 'c',
                     description: 'After starting dynamodb local, create dynamodb tables and run seeds'
                 }, {
-                    option: 'downloadDirectory',
+                    option: 'downloadFrom',
                     shortcut: 'D',
                     description: 'Specify the path where you want to download dynamodb. Default path is serverless-dynamodb-local/dynamodb/bin'
                 }]
@@ -132,7 +132,7 @@ module.exports = function(S) { // Always pass in the ServerlessPlugin Class
                     options = _.merge({
                             sharedDb: evt.options.sharedDb || true
                         },
-                        evt.options,
+                        evt.options, { downloadFrom: config.downloadFrom },
                         config && config.start
                     ),
                     _spinner = SCli.spinner();


### PR DESCRIPTION
Added downloadDirectory path to both cli param as well as s-project configuration. 
 **CLI** 
sls dynamodb start -D [path_of_the_download_directory]
-or-
**s-project.json**
"custom": {
        "dynamodb": {
           "downloadFrom": "D:\\workspaces\\Severless\\test_project\\my-db"
            "start": {
                "port": "8005"
            }}}
