### PR TITLE
Updating the dynamodb-migrations version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "serverless-dynamodb-local",
-    "version": "0.2.10",
+    "version": "0.2.11",
     "engines": {
         "node": ">=4.0"
     },
@@ -39,7 +39,7 @@
         "aws-sdk": "^2.3.19",
         "bluebird": "^3.0.6",
         "dynamodb-localhost": "0.0.2",
-        "dynamodb-migrations": "0.0.9",
+        "dynamodb-migrations": "0.0.10",
         "lodash": "^4.13.1",
         "mkdirp": "^0.5.0",
         "tar": "^2.0.0"


### PR DESCRIPTION
Updating the dynamodb-migrations version to fix executeAll allowing only to filter .json extension
Fix for #50 