### PR TITLE
Add compatibility with serverless-offline plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,20 @@ new AWS.DynamoDB({
 ### Using with serverless-offline plugin
 When using this plugin with serverless-offline, it is difficult to use above syntax since the code should use DynamoDB Local for development, and use DynamoDB Online after provisioning in AWS. Therefore we suggest you to use [serverless-dynamodb-client](https://github.com/99xt/serverless-dynamodb-client) plugin in your code.
 
+The `serverless dynamodb start` command can be triggered automatically when using `serverless-offline` plugin.
+Please note that you still need to install DynamoDB Local first.
+
+Add both plugins to your `serverless.yml` file:
+```yaml
+plugins:
+  - serverless-dynamodb-local
+  - serverless-offline
+```
+
+Make sure that `serverless-dynamodb-local` is above `serverless-offline` so it will be loaded earlier.
+
+Now your local DynamoDB database will be automatically started before running `serverless offline`.
+
 ## Reference Project
 * [serverless-react-boilerplate](https://github.com/99xt/serverless-react-boilerplate)
 

--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ class ServerlessDynamodbLocal {
             'dynamodb:remove:removeHandler': this.removeHandler.bind(this),
             'dynamodb:install:installHandler': this.installHandler.bind(this),
             'dynamodb:start:startHandler': this.startHandler.bind(this),
+            'before:offline:start': this.startHandler.bind(this),
         };
     }
     createHandler() {

--- a/package.json
+++ b/package.json
@@ -31,17 +31,11 @@
     "scripts": {
         "test": "echo \"Warning: no test specified\" && exit 0"
     },
-    "devDependencies": {
-        "chai": "^3.2.0",
-        "mocha": "^2.2.5"
-    },
     "dependencies": {
-        "aws-sdk": "^2.3.19",
-        "bluebird": "^3.0.6",
-        "dynamodb-localhost": "0.0.2",
-        "dynamodb-migrations": "0.0.10",
-        "lodash": "^4.13.1",
-        "mkdirp": "^0.5.0",
-        "tar": "^2.0.0"
+        "aws-sdk": "^2.7.0",
+        "bluebird": "^3.4.6",
+        "dynamodb-localhost": "^0.0.4",
+        "dynamodb-migrations": "^0.0.10",
+        "lodash": "^4.17.0"
     }
 }


### PR DESCRIPTION
This PR adds a hook to automatically start local dynamodb database before running serverless-offline plugin. I added a note about it to README. And while there, updated project dependencies.