### PR TITLE
	fix credentials error for aws-sdk

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,8 +140,8 @@ class ServerlessDynamodbLocal {
 				dynamoOptions = {
 			endpoint: 'http://localhost:' + port,
 			region: 'localhost',
-			accessKeyId: '1234',
-			secretAccessKey: '1234'
+			accessKeyId: 'MOCK_ACCESS_KEY_ID',
+			secretAccessKey: 'MOCK_SECRET_ACCESS_KEY'
                 };
 			}		
 			return {


### PR DESCRIPTION
An error saying "Could not load credentials from any providers" happens when trying to use migrate with no default aws-sdk profile set.
This is a quick fix for this kind of error, which doesn't make the user use a default aws-sdk profile.