### PR TITLE
Forced Table Prefix Bug Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ class ServerlessDynamodbLocal {
         
         return new BbPromise(function(resolve, reject) {
             let dynamodb = self.dynamodbOptions(region),
-                tableOptions = self.tableOptions(options.stage);
+                tableOptions = self.tableOptions();
 	        dynamodbMigrations.init(dynamodb, tableOptions.path);
             dynamodbMigrations.executeAll(tableOptions).then(resolve, reject);
         });


### PR DESCRIPTION
Tables were getting automatically prefixed with the stage during start as a result of commit 5da9b02.