### PR TITLE
DynamoDB tables created directly from Resources declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ serverless-dynamodb-local
 ## Features
 * Install DynamoDB Local
 * Start DynamoDB Local with all the parameters supported (e.g port, inMemory, sharedDb)
-* Create, Manage and Execute DynamoDB Migration Scripts(Table Creation/ Data Seeds) for DynamoDB Local and Online
+* Table Creation for DynamoDB Local
 
 ## Install Plugin
 `npm install --save serverless-dynamodb-local`
@@ -28,18 +28,11 @@ plugins:
 1) Install DynamoDB Local
 `sls dynamodb install`
 
-2) Start DynamoDB Local (DynamoDB will process incoming requests until you stop it. To stop DynamoDB, type Ctrl+C in the command prompt window). Make sure above command is executed before this.
-`sls dynamodb start`
+2) Add DynamoDB Resource definitions to your Serverless configuration, as defined here: https://serverless.com/framework/docs/providers/aws/guide/resources/#configuration
 
-3) Create/Execute DynamoDB (Migrations)
-* Create a new migration file (Default directory path /dynamodb). Make sure DynamoDB Local is started in another shell.
-`sls dynamodb create -n <filename>`
+3) Start DynamoDB Local and migrate (DynamoDB will process incoming requests until you stop it. To stop DynamoDB, type Ctrl+C in the command prompt window). Make sure above command is executed before this.
+`sls dynamodb start --migrate`
 
-* Execute a single migration. Make sure DynamoDB Local is started in another shell.
-`sls dynamodb execute -n <filename>`
-
-* Execute all migrations on the remote dynamodb.
-`sls dynamodb executeAll`
 
 Note: Read the detailed section for more information on advanced options and configurations. Open a browser and go to the url http://localhost:8000/shell to access the web shell for dynamodb local.
 
@@ -59,7 +52,7 @@ All CLI options are optional:
 --sharedDb                -h  DynamoDB will use a single database file, instead of using separate files for each credential and region. If you specify -sharedDb, all DynamoDB clients will interact with the same set of tables regardless of their region and credential configuration.
 --delayTransientStatuses  -t  Causes DynamoDB to introduce delays for certain operations. DynamoDB can perform some tasks almost instantaneously, such as create/update/delete operations on tables and indexes; however, the actual DynamoDB service requires more time for these tasks. Setting this parameter helps DynamoDB simulate the behavior of the Amazon DynamoDB web service more closely. (Currently, this parameter introduces delays only for global secondary indexes that are in either CREATING or DELETING status.)
 --optimizeDbBeforeStartup -o  Optimizes the underlying database tables before starting up DynamoDB on your computer. You must also specify -dbPath when you use this parameter.
---migration               -m  After starting dynamodb local, run dynamodb migrations.
+--migrate                 -m  After starting DynamoDB local, create DynamoDB tables from the Serverless configuration..
 ```
 
 All the above options can be added to serverless.yml to set default configuration: e.g.
@@ -71,20 +64,17 @@ custom:
       port: 8000
       inMemory: true
       migration: true
-    migration:
-      dir: ./offline/migrations
 ```
 
-##  Migrations: sls dynamodb create/execute/executeAll
+##  Migrations: sls dynamodb migrate
 ### Configurations
-In `serverless.yml` add following to customize DynamoDB Migrations file directory and table prefixes/suffixes
+In `serverless.yml` add following to customize DynamoDB Migrations table prefixes/suffixes
 ```yml
 custom:
   dynamodb:
     migration:
-      dir: dynamodbMigrations
-        table_prefix: prefix
-        table_suffix": suffix
+      table_prefix: prefix
+      table_suffix": suffix
 ```
 
 In `serverless.yml` add following to execute all the migration upon DynamoDB Local Start
@@ -92,71 +82,26 @@ In `serverless.yml` add following to execute all the migration upon DynamoDB Loc
 custom:
   dynamodb:
     start:
-      migration: true
+      migrate: true
 ```
-### Migration Template
-```json
-{
-    "Table": {
-        "TableName": "TableName",
-        "KeySchema": [{
-            "AttributeName": "attr_1",
-            "KeyType": "HASH"
-		}, {
-            "AttributeName": "attr_2",
-            "KeyType": "RANGE"
-		}],
-        "AttributeDefinitions": [{
-            "AttributeName": "attr_1",
-            "AttributeType": "S"
-		}, {
-            "AttributeName": "attr_2",
-            "AttributeType": "S"
-		}],
-        "LocalSecondaryIndexes": [{
-            "IndexName": "local_index_1",
-            "KeySchema": [{
-                "AttributeName": "attr_1",
-                "KeyType": "HASH"
-			}, {
-                "AttributeName": "attr_2",
-                "KeyType": "RANGE"
-			}],
-            "Projection": {
-                "NonKeyAttributes": ["attr_1", "attr_2"],
-                "ProjectionType": "INCLUDE"
-            }
-		}],
-        "GlobalSecondaryIndexes": [{
-            "IndexName": "global_index_1",
-            "KeySchema": [{
-                "AttributeName": "attr_1",
-                "KeyType": "HASH"
-			}, {
-                "AttributeName": "attr_2",
-                "KeyType": "RANGE"
-			}],
-            "Projection": {
-                "NonKeyAttributes": ["attr_1", "attr_2"],
-                "ProjectionType": "INCLUDE"
-            },
-            "ProvisionedThroughput": {
-                "ReadCapacityUnits": 1,
-                "WriteCapacityUnits": 1
-            }
-		}],
-        "ProvisionedThroughput": {
-            "ReadCapacityUnits": 1,
-            "WriteCapacityUnits": 1
-        }
-    },
-    "Seeds": [{
-        "attr_1": "attr_1_value",
-        "attr_2": "attr_2_value"
-    }]
-}
+### AWS::DynamoDB::Table Resource Template for serverless.yml
+```yml
+resources:
+  Resources:
+    usersTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: usersTable
+        AttributeDefinitions:
+          - AttributeName: email
+            AttributeType: S
+        KeySchema:
+          - AttributeName: email
+            KeyType: HASH
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1
 ```
-Before modifying the migration template, refer the (Dynamodb Client SDK): http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#createTable-property and (Dynamodb Document Client SDK): http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#put-property links.
 
 ## Using DynamoDB Local in your code
 You need to add the following parameters to the AWS NODE SDK dynamodb constructor

--- a/README.md
+++ b/README.md
@@ -68,15 +68,6 @@ custom:
 
 ##  Migrations: sls dynamodb migrate
 ### Configurations
-In `serverless.yml` add following to customize DynamoDB Migrations table prefixes/suffixes
-```yml
-custom:
-  dynamodb:
-    migration:
-      table_prefix: prefix
-      table_suffix": suffix
-```
-
 In `serverless.yml` add following to execute all the migration upon DynamoDB Local Start
 ```yml
 custom:

--- a/index.js
+++ b/index.js
@@ -16,15 +16,11 @@ class ServerlessDynamodbLocal {
                 commands: {
                     migrate: {
                         lifecycleEvents: ['migrateHandler'],
-                        options: {
-                            stage: {
-                                shortcut: 'm',
-                                usage: 'Create DynamoDB tables from the current serverless configuration'
-                            }
-                        }
+                        usage: 'Creates local DynamoDB tables from the current Serverless configuration'
                     },
                     start: {
                         lifecycleEvents: ['startHandler'],
+                        usage: 'Starts local DynamoDB',
                         options: {
                             port: {
                                 shortcut: 'p',
@@ -61,9 +57,11 @@ class ServerlessDynamodbLocal {
                         }
                     },
                     remove: {
-                        lifecycleEvents: ['removeHandler']
+                        lifecycleEvents: ['removeHandler'],
+                        usage: 'Removes local DynamoDB'
                     },
                     install: {
+                        usage: 'Installs local DynamoDB',
                         lifecycleEvents: ['installHandler'],
                         options: {
                             localPath: {
@@ -103,30 +101,15 @@ class ServerlessDynamodbLocal {
         };
     }
 
-    tableOptions(table_prefix, table_suffix) {
-        let self = this;
-        let config = self.service.custom.dynamodb,
-            migration = config && config.migration || {},
-            suffix = table_suffix || migration.table_suffix || '',
-            prefix = table_prefix || migration.table_prefix || '';
-
-        return {
-            suffix: suffix,
-            prefix: prefix
-        };
-    }
-
     migrateHandler() {
         let self = this;
 
         return new BbPromise(function (resolve, reject) {
-            let dynamodb = self.dynamodbOptions(),
-                tableOptions = self.tableOptions();
+            let dynamodb = self.dynamodbOptions();
 
             var tables = self.resourceTables();
 
             return BbPromise.each(tables, function (table) {
-                table.TableName = self.formatTableName(table, tableOptions);
                 return self.createTable(dynamodb, table);
             }).then(resolve, reject);
         });
@@ -190,10 +173,6 @@ class ServerlessDynamodbLocal {
                 resolve(migration);
             });
         });
-    }
-
-    formatTableName(table, options) {
-        return options.prefix + table.TableName + options.suffix;
     }
 }
 module.exports = ServerlessDynamodbLocal;

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "serverless-dynamodb-local",
-    "version": "0.2.15",
-    "engines": {
-        "node": ">=4.0"
-    },
-    "description": "Serverless dynamodb local plugin",
-    "author": "99xtechnology.com",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/99xt/serverless-dynamodb-local"
-    },
-    "keywords": [
+  "name": "serverless-dynamodb-local",
+  "version": "0.2.15",
+  "engines": {
+    "node": ">=4.0"
+  },
+  "description": "Serverless dynamodb local plugin",
+  "author": "99xtechnology.com",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/99xt/serverless-dynamodb-local"
+  },
+  "keywords": [
     "serverless framework plugin",
     "serverless applications",
     "serverless plugins",
@@ -26,16 +26,15 @@
     "amazon web services",
     "serverless.com"
   ],
-    "main": "index.js",
-    "bin": {},
-    "scripts": {
-        "test": "echo \"Warning: no test specified\" && exit 0"
-    },
-    "dependencies": {
-        "aws-sdk": "^2.7.0",
-        "bluebird": "^3.4.6",
-        "dynamodb-localhost": "^0.0.4",
-        "dynamodb-migrations": "^0.0.10",
-        "lodash": "^4.17.0"
-    }
+  "main": "index.js",
+  "bin": {},
+  "scripts": {
+    "test": "echo \"Warning: no test specified\" && exit 0"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.7.0",
+    "bluebird": "^3.4.6",
+    "dynamodb-localhost": "^0.0.4",
+    "lodash": "^4.17.0"
+  }
 }


### PR DESCRIPTION
As mentioned in #56, this PR will create local DynamoDB tables solely from the serverless.yml Resources declaration. Consequently, this PR removes the existing ability to seed data. It also removes the ability to set table prefixes or suffixes, as this will do only what is configured in Resources to mimic what would be deployed by Serverless. In #56, @AshanFernando outlined the creation of a separate dynamodb-seeds plugin to add back the ability to seed DynamoDB tables. I have not had a chance to create that yet.