### PR TITLE
add option to prevent dynamodb from starting with serverless-offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,11 @@ plugins:
 
 Make sure that `serverless-dynamodb-local` is above `serverless-offline` so it will be loaded earlier.
 
-Now your local DynamoDB database will be automatically started before running `serverless offline`.
+Now your local DynamoDB database will be automatically started before running `serverless offline`.  If you don't want DynamoDB to be automatically started, add the following to your `serverless.yml`:
+```
+dynamodb:
+    nostart: true
+```
 
 ## Reference Project
 * [serverless-react-boilerplate](https://github.com/99xt/serverless-react-boilerplate)

--- a/index.js
+++ b/index.js
@@ -152,6 +152,10 @@ class ServerlessDynamodbLocal {
             config && config.start
         );
 
+        if (config && config.nostart) {
+            return;
+        }
+
         dynamodbLocal.start(options);
         return BbPromise.resolve()
         .then(() => options.migrate && this.migrateHandler())
@@ -159,6 +163,10 @@ class ServerlessDynamodbLocal {
     }
 
     endHandler() {
+        if (this.config && this.config.nostart) {
+            return;
+        }
+
         this.serverlessLog('DynamoDB - stopping local database');
         dynamodbLocal.stop(this.port);
     }


### PR DESCRIPTION
I'm not sure this is the best way to do this, but I'm running dynamodb in a docker container and the hook into serverless offline calls start no matter what, which crashes everything.  With this short circuit, everything's great for me.