### PR TITLE
Fixes ‘serverless dynamodb seed’ not working

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ class ServerlessDynamodbLocal {
 
         this.hooks = {
             "dynamodb:migrate:migrateHandler": this.migrateHandler.bind(this),
-            "dynamodb:migrate:seedHandler": this.seedHandler.bind(this),
+            "dynamodb:seed:seedHandler": this.seedHandler.bind(this),
             "dynamodb:remove:removeHandler": this.removeHandler.bind(this),
             "dynamodb:install:installHandler": this.installHandler.bind(this),
             "dynamodb:start:startHandler": this.startHandler.bind(this),


### PR DESCRIPTION
The `serverless dynamodb seed` command wasn't working in the latest release because the hook was set under the migrate command ( related to #84 and #85 ), this solves it.