### PR TITLE
Delete ttl from dynamodb table CloudFormation specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ resources:
           WriteCapacityUnits: 1
 ```
 
+**Note:**
+DynamoDB local doesn't support TTL specification, therefore plugin will simply ignore ttl configuration from Cloudformation template.
+
 ## Seeding: sls dynamodb seed
 ### Configuration
 

--- a/index.js
+++ b/index.js
@@ -200,6 +200,9 @@ class ServerlessDynamodbLocal {
             if (migration.StreamSpecification && migration.StreamSpecification.StreamViewType) {
                 migration.StreamSpecification.StreamEnabled = true;
             }
+            if (migration.TimeToLiveSpecification) {
+              delete migration.TimeToLiveSpecification;
+            }
             dynamodb.raw.createTable(migration, (err) => {
                 if (err) {
                     this.serverlessLog("DynamoDB - Error - ", err);


### PR DESCRIPTION
With the recent release of [CloudFormation](https://aws.amazon.com/about-aws/whats-new/2017/07/aws-cloudformation-coverage-updates-for-amazon-api-gateway--amazon-ec2--amazon-emr--amazon-dynamodb-and-more/?sc_channel=em&sc_campaign=Launch_RN20170711&sc_publisher=aws&sc_medium=em_&sc_content=launch_la_nontier1&sc_country=&sc_geo=&sc_category=mult&sc_outcome=launch&mkt_tok=eyJpIjoiWkRobU1EY3pPREl5WXpNMiIsInQiOiJmZUR0MlFMVFpLZUtvek9mUXN0SjFrWlBEc25uZVdZSGlpdnJwdVlERGk4QnVzeEE0QmttbDg0NkI3RElkU1pDak9rRmwzNlNxdVBUXC9Gb1lyMFo3QUVoV2ZsdDlGbWNFVU9ZT0Vja2dNN3EzQzlXYjkwbkM4all2R3BOeDJnT0kifQ%3D%3D) it supports configuring TTL for dynamodb but this is [not supported](https://forums.aws.amazon.com/thread.jspa?threadID=251088) by dynamodb local.

That's why we need to exclude ttl specification before creating local dynamodb table