### PR TITLE
Include tables from additional stacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,7 @@ class ServerlessDynamodbLocal {
             stacks = stacks.concat(this.getAdditionalStacks());
         }
 
-        return stacks.map(stack => this.getTableDefinitionsFromStack(stack)).reduce((tables, tablesInStack) => tables.concat(tablesInStack), []);
+        return stacks.map((stack) => this.getTableDefinitionsFromStack(stack)).reduce((tables, tablesInStack) => tables.concat(tablesInStack), []);
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -163,16 +163,43 @@ class ServerlessDynamodbLocal {
         dynamodbLocal.stop(this.port);
     }
 
-    /**
-     * Gets the table definitions
-     */
-    get tables() {
-        const resources = this.service.resources.Resources;
+    getDefaultStack() {
+        return _.get(this.service, "resources");
+    }
+
+    getAdditionalStacks() {
+        return _.values(_.get(this.service, "custom.additionalStacks", {}));
+    }
+
+    hasAdditionalStacksPlugin() {
+        return _.get(this.service, "plugins", []).includes("serverless-plugin-additional-stacks");
+    }
+
+    getTableDefinitionsFromStack(stack) {
+        const resources = _.get(stack, "Resources", []);
         return Object.keys(resources).map((key) => {
             if (resources[key].Type === "AWS::DynamoDB::Table") {
                 return resources[key].Properties;
             }
         }).filter((n) => n);
+    }
+
+    /**
+     * Gets the table definitions
+     */
+    get tables() {
+        let stacks = [];
+
+        const defaultStack = this.getDefaultStack();
+        if (defaultStack) {
+            stacks.push(defaultStack);
+        }
+
+        if (this.hasAdditionalStacksPlugin()) {
+            stacks = stacks.concat(this.getAdditionalStacks());
+        }
+
+        return stacks.map(stack => this.getTableDefinitionsFromStack(stack)).reduce((tables, tablesInStack) => tables.concat(tablesInStack), []);
     }
 
     /**


### PR DESCRIPTION
#101 took a stab at this, but it didn't really work, so I fixed it myself.

This PR does two things:

1. Makes the plugin not crash if you haven't defined `resources` in your serverless.yml. I don't have any resources in my main stack, so this was a problem for me.

2. If serverless-plugin-additional-stacks is enabled, we look for tables in those stacks as well.

Closes #101.