### PR TITLE
Adding a `noStart` option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ custom:
       inMemory: true
       migrate: true
       seed: true
+    # Uncomment only if you already have a DynamoDB running locally
+    # noStart: true
 ```
 
 ##  Migrations: sls dynamodb migrate

--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ class ServerlessDynamodbLocal {
 
     endHandler() {
         if (!this.options.noStart) {
-            this.serverlessLog('DynamoDB - stopping local database');
+            this.serverlessLog("DynamoDB - stopping local database");
             dynamodbLocal.stop(this.port);
         }
     }

--- a/index.js
+++ b/index.js
@@ -66,6 +66,11 @@ class ServerlessDynamodbLocal {
                             }
                         }
                     },
+                    noStart: {
+                      shortcut: "n",
+                      default: false,
+                      usage: "Do not start DynamoDB local (in case it is already running)",
+                    },
                     remove: {
                         lifecycleEvents: ["removeHandler"],
                         usage: "Removes local DynamoDB"
@@ -144,23 +149,27 @@ class ServerlessDynamodbLocal {
     }
 
     startHandler() {
-        const config = this.config;
-        const options = _.merge({
-                sharedDb: this.options.sharedDb || true
-            },
-            config && config.start,
-            this.options
-        );
+        if (!this.options.noStart) {
+          const config = this.config;
+          const options = _.merge({
+                  sharedDb: this.options.sharedDb || true
+              },
+              config && config.start,
+              this.options
+          );
 
-        dynamodbLocal.start(options);
+          dynamodbLocal.start(options);
+        }
         return BbPromise.resolve()
         .then(() => options.migrate && this.migrateHandler())
         .then(() => options.seed && this.seedHandler());
     }
 
     endHandler() {
-        this.serverlessLog('DynamoDB - stopping local database');
-        dynamodbLocal.stop(this.port);
+        if (!this.options.noStart) {
+            this.serverlessLog('DynamoDB - stopping local database');
+            dynamodbLocal.stop(this.port);
+        }
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "serverless-dynamodb-local",
-    "version": "0.2.22",
+    "version": "0.2.23",
     "engines": {
         "node": ">=4.0"
     },
@@ -12,20 +12,20 @@
         "url": "https://github.com/99xt/serverless-dynamodb-local"
     },
     "keywords": [
-    "serverless framework plugin",
-    "serverless applications",
-    "serverless plugins",
-    "api gateway",
-    "lambda",
-    "dynamodb",
-    "dynamodb local",
-    "aws",
-    "aws lambda",
-    "aws dynamodb",
-    "amazon",
-    "amazon web services",
-    "serverless.com"
-  ],
+        "serverless framework plugin",
+        "serverless applications",
+        "serverless plugins",
+        "api gateway",
+        "lambda",
+        "dynamodb",
+        "dynamodb local",
+        "aws",
+        "aws lambda",
+        "aws dynamodb",
+        "amazon",
+        "amazon web services",
+        "serverless.com"
+    ],
     "main": "index.js",
     "bin": {},
     "scripts": {
@@ -36,5 +36,10 @@
         "bluebird": "^3.4.6",
         "dynamodb-localhost": "^0.0.5",
         "lodash": "^4.17.0"
+    },
+    "devDependencies": {
+        "chai": "^4.1.1",
+        "mocha": "^3.5.0",
+        "should": "^11.2.1"
     }
 }

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -15,7 +15,7 @@ describe("Port function",function(){
   });
 
   it("Port value should be >= 0 and < 65536",function () {
-  http.get(dataApp.prototype.port, function (response) {
+  http.get(`http://localhost:${dataApp.prototype.port}`, function (response) {
     assert.equal(response.statusCode, 200);
     });
   });


### PR DESCRIPTION
- adding a `noStart` option in case you already have a server running. Use case: multiple microservices running in parallel with one shared dynamodb local instance
- adding mocha, chai and should in devDependencies
- update package version
- IMO fixed a test that was failing: 'Port value should be >= 0 and < 65536':