### PR TITLE
Fixing 'undefined variable options' error when noStart was not provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,15 +149,14 @@ class ServerlessDynamodbLocal {
     }
 
     startHandler() {
-        if (!this.options.noStart) {
-          const config = this.config;
-          const options = _.merge({
-                  sharedDb: this.options.sharedDb || true
-              },
-              config && config.start,
-              this.options
-          );
-
+        const config = this.config;
+        const options = _.merge({
+                sharedDb: this.options.sharedDb || true
+            },
+            config && config.start,
+            this.options
+        );
+        if (!options.noStart) {
           dynamodbLocal.start(options);
         }
         return BbPromise.resolve()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "serverless-dynamodb-local",
-    "version": "0.2.23",
+    "version": "0.2.24",
     "engines": {
         "node": ">=4.0"
     },


### PR DESCRIPTION
This should fix https://github.com/99xt/serverless-dynamodb-local/issues/116