### PR TITLE
Fixing seeding command issue without --seed params

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ class ServerlessDynamodbLocal {
     get seedSources() {
         const config = this.service.custom.dynamodb;
         const seedConfig = _.get(config, "seed", {});
-        const seed = this.options.seed || config.start.seed;
+        const seed = this.options.seed || config.start.seed || seedConfig;
         let categories;
         if (typeof seed === "string") {
             categories = seed.split(",");


### PR DESCRIPTION
Fixes issue #138 

In addition to checking  
`const seed = this.options.seed || config.start.seed;`
also appended seedConfig availability as follows
`const seed = this.options.seed || config.start.seed || seedConfig;`
