### PR TITLE
Moved config loading from constructor to methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ class ServerlessDynamodbLocal {
         this.serverless = serverless;
         this.service = serverless.service;
         this.serverlessLog = serverless.cli.log.bind(serverless.cli);
-        this.config = this.service.custom && this.service.custom.dynamodb || {};
         this.options = options;
         this.provider = "aws";
         this.commands = {
@@ -102,13 +101,13 @@ class ServerlessDynamodbLocal {
     }
 
     get port() {
-        const config = this.config;
+        const config = this.service.custom && this.service.custom.dynamodb || {};
         const port = _.get(config, "start.port", 8000);
         return port;
     }
 
     get host() {
-        const config = this.config;
+        const config = this.service.custom && this.service.custom.dynamodb || {};
         const host = _.get(config, "start.host", "localhost");
         return host;
     }
@@ -155,7 +154,7 @@ class ServerlessDynamodbLocal {
     }
 
     startHandler() {
-        const config = this.config;
+        const config = this.service.custom && this.service.custom.dynamodb || {};
         const options = _.merge({
                 sharedDb: this.options.sharedDb || true
             },

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -17,6 +17,7 @@ describe("Port function",function(){
   });
 
   it("Port value should be >= 0 and < 65536",function(done){
+    let service = new Plugin(serverlessMock, {});
     http.get(`http://localhost:${service.port}/shell/`, function (response) {
       assert.equal(response.statusCode, 200);
       done();

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -6,19 +6,18 @@ const expect = require("chai").expect;
 const should = require("should");
 const aws = require ("aws-sdk");
 const seeder = require("../src/seeder.js");
-const dataApp = require("../index.js");
+const Plugin = require("../index.js");
 
-const serverlessMock = require('./serverlessMock');
+const serverlessMock = require("./serverlessMock");
 
 describe("Port function",function(){
   it("Port should return number",function(){
-    let service = new dataApp(serverlessMock, {});
-    let myport = service.port;
-    assert(typeof myport, "number");
+    let service = new Plugin(serverlessMock, {});
+    assert(typeof service.port, "number");
   });
 
   it("Port value should be >= 0 and < 65536",function () {
-    let service = new dataApp(serverlessMock, {});
+    let service = new Plugin(serverlessMock, {});
     http.get(`http://localhost:${service.port}`, function (response) {
       assert.equal(response.statusCode, 200);
     });
@@ -37,13 +36,13 @@ describe("Check the dynamodb function",function(){
     });
 
   it("Should be an object",function(){
-    let dynamoOptions = dataApp.prototype.dynamodbOptions;
+    let dynamoOptions = Plugin.prototype.dynamodbOptions;
     let raw = new aws.DynamoDB(dynamoOptions);
     raw.should.be.type("object");
   });
   
   it("Should be an object",function(){
-    let dynamoOptions =  dataApp.prototype.dynamodbOptions;
+    let dynamoOptions =  Plugin.prototype.dynamodbOptions;
     let doc = new aws.DynamoDB(dynamoOptions);
     doc.should.be.type("object");
   });
@@ -51,7 +50,7 @@ describe("Check the dynamodb function",function(){
 
 describe ("Start handler function",function(){
   it ("Should not  be null",function(){
-    let handler = dataApp.prototype.startHandler;
+    let handler = Plugin.prototype.startHandler;
     assert(handler =! null);
   });
 });
@@ -59,7 +58,7 @@ describe ("Start handler function",function(){
 
 describe ("createTable functon",function(){
   it ("Should check as a function",function(){
-    const tbl = dataApp.prototype.createTable;
+    const tbl = Plugin.prototype.createTable;
     assert.equal(typeof tbl, "function");
   });
 }); 

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -8,15 +8,19 @@ const aws = require ("aws-sdk");
 const seeder = require("../src/seeder.js");
 const dataApp = require("../index.js");
 
+const serverlessMock = require('./serverlessMock');
+
 describe("Port function",function(){
   it("Port should return number",function(){
-    let myport = dataApp.prototype.port;
+    let service = new dataApp(serverlessMock, {});
+    let myport = service.port;
     assert(typeof myport, "number");
   });
 
   it("Port value should be >= 0 and < 65536",function () {
-  http.get(`http://localhost:${dataApp.prototype.port}`, function (response) {
-    assert.equal(response.statusCode, 200);
+    let service = new dataApp(serverlessMock, {});
+    http.get(`http://localhost:${service.port}`, function (response) {
+      assert.equal(response.statusCode, 200);
     });
   });
 });

--- a/test/serverlessMock.js
+++ b/test/serverlessMock.js
@@ -1,0 +1,7 @@
+module.exports = {
+    service: {},
+    cli: {
+        log: () => {}
+    },
+    custom: {}
+};


### PR DESCRIPTION
This allows variables to be passed in to the plugin

Fixes issue #141

Changes: Moves `this.config` from constructor to each method that requires use of `dynamodb` config from `custom`.
