### PR TITLE
Removing Tags property in table definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,6 +248,9 @@ class ServerlessDynamodbLocal {
             if (migration.Tags) {
               delete migration.Tags;
             }
+            if (migration.SSESpecification) {
+              delete migration.SSESpecification;
+            }
             dynamodb.raw.createTable(migration, (err) => {
                 if (err) {
                     if (err.name === 'ResourceInUseException') {

--- a/index.js
+++ b/index.js
@@ -244,6 +244,10 @@ class ServerlessDynamodbLocal {
             if (migration.TimeToLiveSpecification) {
               delete migration.TimeToLiveSpecification;
             }
+            // Tags are supported in Cloud Formation, but not in DynamoDB API
+            if (migration.Tags) {
+              delete migration.Tags;
+            }
             dynamodb.raw.createTable(migration, (err) => {
                 if (err) {
                     this.serverlessLog("DynamoDB - Error - ", err);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dependencies": {
         "aws-sdk": "^2.3.19",
         "bluebird": "^3.0.6",
-        "dynamodb-localhost": "0.0.2",
+        "dynamodb-localhost": "0.0.5",
         "dynamodb-migrations": "0.0.10",
         "lodash": "^4.13.1",
         "mkdirp": "^0.5.0",


### PR DESCRIPTION
Tags property is only supported in cloud formation templates, and not in DynamoDB API.

Fixes issue: `serverless offline start` fail when specifying Tags
```
Serverless: Watching with Webpack...
Serverless: DynamoDB - Error -

  Unexpected Parameter -----------------------------------

  Unexpected key 'Tags' found in params

     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Forums:        forum.serverless.com
     Chat:          gitter.im/serverless/serverless

  Your Environment Information -----------------------------
     OS:                     darwin
     Node Version:           6.11.4
     Serverless Version:     1.24.1
```

Changes: Like for TimeToLive, we are removing the property before creating the table.