### PR TITLE
fix: save merged options to inform endHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,6 +162,9 @@ class ServerlessDynamodbLocal {
             config && config.start,
             this.options
         );
+
+        // otherwise endHandler will be mis-informed
+        this.options = options;
         if (!options.noStart) {
           dynamodbLocal.start(options);
         }


### PR DESCRIPTION
in my particular case, endHandler didn't know `noStart` was true, so it was trying to stop a server that was never started

Changes: save merged options in startHandler
