### PR TITLE
Support for Server Side Encryption specification

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,6 +247,10 @@ class ServerlessDynamodbLocal {
             if (migration.TimeToLiveSpecification) {
               delete migration.TimeToLiveSpecification;
             }
+            if (migration.SSESpecification) {
+              migration.SSESpecification.Enabled = migration.SSESpecification.SSEEnabled;
+              delete migration.SSESpecification.SSEEnabled;
+            }
             dynamodb.raw.createTable(migration, (err) => {
                 if (err) {
                     if (err.name === 'ResourceInUseException') {


### PR DESCRIPTION
There is no issue open for this problem, but if you want to turn on server side encryption for your tables you cannot use offline development anymore, because CloudFormation syntax is different than the JSON object required by createTable function.

Current error:
```
MultipleValidationErrors: There were 2 validation errors:
MissingRequiredParameter: Missing required key 'Enabled' in params.SSESpecification
UnexpectedParameter: Unexpected key 'SSEEnabled' found in params.SSESpecification
at ParamValidator.validate (/Users/myuser/project/path/node_modules/aws-sdk/lib/param_validator.js:40:28)
```

CloudFormation docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html#cfn-dynamodb-table-ssespecification-sseenabled

SSESpecification object: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html#DDB-CreateTable-request-SSESpecification