### PR TITLE
Remove table Tags in order to pass param validation while creating table

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,6 +251,9 @@ class ServerlessDynamodbLocal {
               migration.SSESpecification.Enabled = migration.SSESpecification.SSEEnabled;
               delete migration.SSESpecification.SSEEnabled;
             }
+            if (migration.Tags) {
+                delete migration.Tags;
+            }
             dynamodb.raw.createTable(migration, (err) => {
                 if (err) {
                     if (err.name === 'ResourceInUseException') {


### PR DESCRIPTION
Current issue: If you try to tag your DynamoDB tables with the appropriate CF syntax, you will get the following error message when trying to run serverless offline:

```
 UnexpectedParameter: Unexpected key 'Tags' found in params
    at ParamValidator.fail (/Users/myuser/myproject/node_modules/aws-sdk/lib/param_validator.js:50:37)
```

This happens because CreateTable JSON does not support tags:
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html
which are specified in CF template:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html
