### PR TITLE
Update aws-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "test": "mocha ./test"
     },
     "dependencies": {
-        "aws-sdk": "^2.7.0",
+        "aws-sdk": "^2.190.0",
         "bluebird": "^3.4.6",
         "dynamodb-localhost": "^0.0.5",
         "lodash": "^4.17.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "test": "mocha ./test"
     },
     "dependencies": {
-        "aws-sdk": "^2.190.0",
+        "aws-sdk": "^2.292.0",
         "bluebird": "^3.4.6",
         "dynamodb-localhost": "^0.0.5",
         "lodash": "^4.17.0"


### PR DESCRIPTION
This allows newer properties like 'SSESpecification' to pass validation.

Updated to version 2.190.0 as the version present in the lambda environment on 27-02-2018 (https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html)