### PR TITLE
Added functionality to seed tables that are deployed online

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,9 @@ class ServerlessDynamodbLocal {
 
         if(options && options.online){
             this.serverlessLog("Connecting to online tables...");
-            if (!options.region) throw new Error("please specify the region");
+            if (!options.region) { 
+                throw new Error("please specify the region");
+            }
             dynamoOptions = {
                 region: options.region,
             };


### PR DESCRIPTION
Online seed run can be done using the following command

`sls dynamodb seed --online --region us-east-1`

region is a mandatory field.