### PR TITLE
Whitelist stages to run DynamoDB Local

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ All the above options can be added to serverless.yml to set default configuratio
 ```yml
 custom:
   dynamodb:
+  # If you only want to use DynamoDB Local in some stages, declare them here
+    stages:
+      - dev
     start:
       port: 8000
       inMemory: true
@@ -67,9 +70,6 @@ custom:
       seed: true
     # Uncomment only if you already have a DynamoDB running locally
     # noStart: true
-    # If you only want to start DynamoDB in some stages, declare them here
-      stages:
-        - dev
 ```
 
 ##  Migrations: sls dynamodb migrate

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ custom:
       seed: true
     # Uncomment only if you already have a DynamoDB running locally
     # noStart: true
+    # If you only want to start DynamoDB in some stages, declare them here
+      stages:
+        - dev
 ```
 
 ##  Migrations: sls dynamodb migrate

--- a/index.js
+++ b/index.js
@@ -182,9 +182,16 @@ class ServerlessDynamodbLocal {
             this.options
         );
 
+        const stage = options.stage || this.serverless.service.provider.stage
+        let startThisStage = true;
+        if (options.stages && !options.stages.includes(stage)) {
+          startThisStage = false;
+        }
+        options.startThisStage = startThisStage
+
         // otherwise endHandler will be mis-informed
         this.options = options;
-        if (!options.noStart) {
+        if (!options.noStart && startThisStage) {
           dynamodbLocal.start(options);
         }
         return BbPromise.resolve()
@@ -193,7 +200,7 @@ class ServerlessDynamodbLocal {
     }
 
     endHandler() {
-        if (!this.options.noStart) {
+        if (!this.options.noStart && this.options.startThisStage) {
             this.serverlessLog("DynamoDB - stopping local database");
             dynamodbLocal.stop(this.port);
         }

--- a/index.js
+++ b/index.js
@@ -96,11 +96,11 @@ class ServerlessDynamodbLocal {
             }
         };
 
-        const stage = this.options.stage || this.service.provider.stage
+        const stage = this.options.stage || this.service.provider.stage;
         if (this.config.stages && !this.config.stages.includes(stage)) {
           // don't do anything for this stage
-          this.hooks = {}
-          return
+          this.hooks = {};
+          return;
         }
 
         this.hooks = {

--- a/index.js
+++ b/index.js
@@ -96,6 +96,13 @@ class ServerlessDynamodbLocal {
             }
         };
 
+        const stage = this.options.stage || this.service.provider.stage
+        if (this.config.stages && !this.config.stages.includes(stage)) {
+          // don't do anything for this stage
+          this.hooks = {}
+          return
+        }
+
         this.hooks = {
             "dynamodb:migrate:migrateHandler": this.migrateHandler.bind(this),
             "dynamodb:seed:seedHandler": this.seedHandler.bind(this),
@@ -182,16 +189,9 @@ class ServerlessDynamodbLocal {
             this.options
         );
 
-        const stage = options.stage || this.serverless.service.provider.stage
-        let startThisStage = true;
-        if (options.stages && !options.stages.includes(stage)) {
-          startThisStage = false;
-        }
-        options.startThisStage = startThisStage
-
         // otherwise endHandler will be mis-informed
         this.options = options;
-        if (!options.noStart && startThisStage) {
+        if (!options.noStart) {
           dynamodbLocal.start(options);
         }
         return BbPromise.resolve()
@@ -200,7 +200,7 @@ class ServerlessDynamodbLocal {
     }
 
     endHandler() {
-        if (!this.options.noStart && this.options.startThisStage) {
+        if (!this.options.noStart) {
             this.serverlessLog("DynamoDB - stopping local database");
             dynamodbLocal.stop(this.port);
         }


### PR DESCRIPTION
Fixes issue #159 

Changes: Added a `stages` config and checks to verify that dynamodb local should run in the current stage. If no stages config is provided it works as it does today and starts dynamodb.

