### PR TITLE
Allow custom install path

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const BbPromise = require("bluebird");
 const AWS = require("aws-sdk");
 const dynamodbLocal = require("dynamodb-localhost");
 const seeder = require("./src/seeder");
+const path = require('path');
 
 class ServerlessDynamodbLocal {
     constructor(serverless, options) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,11 @@ class ServerlessDynamodbLocal {
         this.service = serverless.service;
         this.serverlessLog = serverless.cli.log.bind(serverless.cli);
         this.config = this.service.custom && this.service.custom.dynamodb || {};
-        this.options = options;
+        this.options = _.merge({
+          localPath: path.join(serverless.config.servicePath, '.dynamodb')
+          },
+          options
+        );
         this.provider = "aws";
         this.commands = {
             dynamodb: {
@@ -124,7 +128,7 @@ class ServerlessDynamodbLocal {
 
         if(options && options.online){
             this.serverlessLog("Connecting to online tables...");
-            if (!options.region) { 
+            if (!options.region) {
                 throw new Error("please specify the region");
             }
             dynamoOptions = {
@@ -152,7 +156,7 @@ class ServerlessDynamodbLocal {
     }
 
     seedHandler() {
-        const options = this.options; 
+        const options = this.options;
         const dynamodb = this.dynamodbOptions(options);
 
         return BbPromise.each(this.seedSources, (source) => {
@@ -179,7 +183,8 @@ class ServerlessDynamodbLocal {
     startHandler() {
         const config = this.config;
         const options = _.merge({
-                sharedDb: this.options.sharedDb || true
+                sharedDb: this.options.sharedDb || true,
+                install_path: this.options.localPath
             },
             config && config.start,
             this.options


### PR DESCRIPTION
Related to: https://github.com/99xt/dynamodb-localhost/issues/22

Requires: https://github.com/99xt/dynamodb-localhost/pull/24

Changes: This implements changes proposed in https://github.com/99xt/dynamodb-localhost/issues/22

Demo Link: I created an npm fork which demonstrates the features working:

```yaml
# in serverless.yml:
plugins:
  - "@aneilbaboo/serverless-dynamodb-local"
```
```shell
# install the plugin, then install dynamo:
npm install @aneilbaboo/serverless-dynamodb-local
serverless dynamodb install # installs to <project-root>/.dynamodb by default
```