### PR TITLE
Added `convertEmptyValues` option to plugin which allows to save NULL types

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ All CLI options are optional:
 --optimizeDbBeforeStartup -o  Optimizes the underlying database tables before starting up DynamoDB on your computer. You must also specify -dbPath when you use this parameter.
 --migrate                 -m  After starting DynamoDB local, create DynamoDB tables from the Serverless configuration.
 --seed                    -s  After starting and migrating dynamodb local, injects seed data into your tables. The --seed option determines which data categories to onload.
+--convertEmptyValues      -e  Set to true if you would like the document client to convert empty values (0-length strings, binary buffers, and sets) to be converted to NULL types when persisting to DynamoDB.
 ```
 
 All the above options can be added to serverless.yml to set default configuration: e.g.
@@ -65,6 +66,7 @@ custom:
       inMemory: true
       migrate: true
       seed: true
+      convertEmptyValues: true
     # Uncomment only if you already have a DynamoDB running locally
     # noStart: true
 ```

--- a/index.js
+++ b/index.js
@@ -69,6 +69,10 @@ class ServerlessDynamodbLocal {
                             seed: {
                                 shortcut: "s",
                                 usage: "After starting and migrating dynamodb local, injects seed data into your tables. The --seed option determines which data categories to onload.",
+                            },
+                            convertEmptyValues: {
+                                shortcut: "e",
+                                usage: "Set to true if you would like the document client to convert empty values (0-length strings, binary buffers, and sets) to be converted to NULL types when persisting to DynamoDB.",
                             }
                         }
                     },
@@ -129,13 +133,15 @@ class ServerlessDynamodbLocal {
             }
             dynamoOptions = {
                 region: options.region,
+                convertEmptyValues: options && options.convertEmptyValues ? options.convertEmptyValues : false,
             };
         } else {
             dynamoOptions = {
                 endpoint: `http://${this.host}:${this.port}`,
                 region: "localhost",
                 accessKeyId: "MOCK_ACCESS_KEY_ID",
-                secretAccessKey: "MOCK_SECRET_ACCESS_KEY"
+                secretAccessKey: "MOCK_SECRET_ACCESS_KEY",
+                convertEmptyValues: options && options.convertEmptyValues ? options.convertEmptyValues : false,
             };
         }
 

--- a/src/seeder.js
+++ b/src/seeder.js
@@ -96,7 +96,8 @@ function fileExists(fileName) {
  */
 function unmarshalBuffer(json) {
   _.forEach(json, function(value, key) {
-    if (value.type==="Buffer") {
+    // Null check to prevent creation of Buffer when value is null
+    if (value !== null && value.type==="Buffer") {
       json[key]= new Buffer(value.data);
     }
   });


### PR DESCRIPTION
Fixes issue #169 & #170 

Changes: 

- Added option to enable convertEmptyValues which will help convert empty values (0-length strings, binary buffers, and sets) to be converted to NULL types when persisting to DynamoDB

- Added null check in seeder to allow seeding of NULL types

Demo Link: NA

Screenshots for the change: NA
