### PR TITLE
Added support for BillingMode (dynamodb on-demand)

### DIFF
--- a/index.js
+++ b/index.js
@@ -304,7 +304,7 @@ class ServerlessDynamodbLocal {
             if (migration.Tags) {
                 delete migration.Tags;
             }
-            if (migration.BillingMode === 'PAY_PER_REQUEST') {
+            if (migration.BillingMode === "PAY_PER_REQUEST") {
                 delete migration.BillingMode;
 
                 const defaultProvisioning = {
@@ -313,7 +313,7 @@ class ServerlessDynamodbLocal {
                 };
                 migration.ProvisionedThroughput = defaultProvisioning;
                 if (migration.GlobalSecondaryIndexes) {
-                    migration.GlobalSecondaryIndexes.forEach(gsi => {
+                    migration.GlobalSecondaryIndexes.forEach((gsi) => {
                         gsi.ProvisionedThroughput = defaultProvisioning;
                     });
                 }

--- a/index.js
+++ b/index.js
@@ -304,7 +304,7 @@ class ServerlessDynamodbLocal {
             if (migration.Tags) {
                 delete migration.Tags;
             }
-            if (migration.BillingMode) {
+            if (migration.BillingMode === 'PAY_PER_REQUEST') {
                 delete migration.BillingMode;
 
                 const defaultProvisioning = {

--- a/index.js
+++ b/index.js
@@ -304,6 +304,19 @@ class ServerlessDynamodbLocal {
             if (migration.Tags) {
                 delete migration.Tags;
             }
+            if (migration.BillingMode) {
+                delete migration.BillingMode;
+                const defaultProvisioning = {
+                    ReadCapacityUnits: 5,
+                    WriteCapacityUnits: 5
+                };
+                migration.ProvisionedThroughput = defaultProvisioning;
+                if (migration.GlobalSecondaryIndexes) {
+                    migration.GlobalSecondaryIndexes.forEach(gsi => {
+                        gsi.ProvisionedThroughput = defaultProvisioning;
+                    });
+                }
+              }
             dynamodb.raw.createTable(migration, (err) => {
                 if (err) {
                     if (err.name === 'ResourceInUseException') {

--- a/index.js
+++ b/index.js
@@ -304,6 +304,15 @@ class ServerlessDynamodbLocal {
             if (migration.Tags) {
                 delete migration.Tags;
             }
+            if (migration.BillingMode) {
+                delete migration.BillingMode;
+                if (!migration.ProvisionedThroughput) {
+                  migration.ProvisionedThroughput = {
+                    ReadCapacityUnits: 5,
+                    WriteCapacityUnits: 5
+                  };
+                }
+              }
             dynamodb.raw.createTable(migration, (err) => {
                 if (err) {
                     if (err.name === 'ResourceInUseException') {


### PR DESCRIPTION
Fixes issue #189 

Changes: Added support for BillingMode

[AWS Docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.UsageNotes.html):
> Provisioned throughput settings are ignored in downloadable DynamoDB, even though the CreateTable operation requires them. For CreateTable, you can specify any numbers you want for provisioned read and write throughput, even though these numbers are not used. You can call UpdateTable as many times as you want per day. However, any changes to provisioned throughput values are ignored.