### PR TITLE
Fix PROVISIONED billing mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,7 +314,7 @@ class ServerlessDynamodbLocal {
             if (migration.Tags) {
                 delete migration.Tags;
             }
-            if (migration.BillingMode === "PAY_PER_REQUEST") {
+            if (migration.BillingMode === "PAY_PER_REQUEST" || migration.BillingMode === "PROVISIONED") {
                 delete migration.BillingMode;
 
                 const defaultProvisioning = {


### PR DESCRIPTION
As [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-billingmode), there are two values we can pass it to billing mode `PROVISIONED` and `PAY_PER_REQUEST`. 

This PR will fix the issue with `PROVISIONED` billing mode.