### PR TITLE
add: dynamodb start port as environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,8 @@ class ServerlessDynamodbLocal {
             };
         }
 
+        process.env.DYNAMODB_LOCAL_PORT = this.port;
+
         return {
             raw: new AWS.DynamoDB(dynamoOptions),
             doc: new AWS.DynamoDB.DocumentClient(dynamoOptions)

--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -23,6 +23,12 @@ describe("Port function",function(){
       done();
     });
   });
+
+  it("Port value should be set as environment variable",function(){
+    let service = new Plugin(serverlessMock, {});
+    service.dynamodbOptions();
+    assert.equal(process.env.DYNAMODB_LOCAL_PORT, 8000);
+  });
 });
 
 describe("Check the dynamodb function",function(){


### PR DESCRIPTION
Changes: adds dynamodb start as port as environment variable. It helps to set dynamodb client in runtime without additional configurations on serverless.yml