### PR TITLE
Fixed hasAdditionalStacksPlugin check if using modules in plugins sec…

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ class ServerlessDynamodbLocal {
     }
 
     hasAdditionalStacksPlugin() {
-        return _.get(this.service, "plugins", []).includes("serverless-plugin-additional-stacks");
+      return _.get(this.service, "plugins.modules", _.get(this.service, "plugins", [])).includes("serverless-plugin-additional-stacks")
     }
 
     getTableDefinitionsFromStack(stack) {


### PR DESCRIPTION
Fixes ` _.get(...).includes is not a function` error if serverless.yml looks like this:
```yml
plugins:
  localPath: './plugins'
  modules:
    - my-custom-plugin
    - serverless-domain-manager
    - serverless-dynamodb-local
    - serverless-offline
```