### PR TITLE
Support enhanced plugins object structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,9 @@ class ServerlessDynamodbLocal {
     }
 
     hasAdditionalStacksPlugin() {
-        return _.get(this.service, "plugins", []).includes("serverless-plugin-additional-stacks");
+        const pluginManager = this.serverless.pluginManager;
+        const modules = pluginManager.parsePluginsObject(this.service.plugins).modules;
+        return modules.includes("serverless-plugin-additional-stacks");
     }
 
     getTableDefinitionsFromStack(stack) {


### PR DESCRIPTION
This plugin doesn't support enhanced plugins object throwing below error 

```
TypeError: _.get(...).includes is not a function
    at ServerlessDynamodbLocal.hasAdditionalStacksPlugin (~/node_modules/serverless-dynamodb-local/index.js:249:51)
```

The serverless plugins section supports two kind of formats:

**Array object:**

```
plugins:
  - plugin1
  - plugin2
```

**Enhanced plugins object:**

```
plugins:
  localPath: './custom_serverless_plugins'
  modules:
    - plugin1
    - plugin2
```

This PR add support for both of them.
