### PR TITLE
Add option to stop the database process

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All CLI options are optional:
 --migrate                 -m  After starting DynamoDB local, create DynamoDB tables from the Serverless configuration.
 --seed                    -s  After starting and migrating dynamodb local, injects seed data into your tables. The --seed option determines which data categories to onload.
 --convertEmptyValues      -e  Set to true if you would like the document client to convert empty values (0-length strings, binary buffers, and sets) to be converted to NULL types when persisting to DynamoDB.
---userStop       After starting dynamodb local and all migrations and seeding is completed (if set to run), process will stay open until user terminates runinng process. When terminate signal received, it will stop the database on the running port.
+--userStop       After starting dynamodb local and all migrations and seeding is completed (if set to run), process will stay open until user terminates running process. When terminate signal received, it will stop the database on the running port.
 ```
 
 All the above options can be added to serverless.yml to set default configuration: e.g.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ All CLI options are optional:
 --migrate                 -m  After starting DynamoDB local, create DynamoDB tables from the Serverless configuration.
 --seed                    -s  After starting and migrating dynamodb local, injects seed data into your tables. The --seed option determines which data categories to onload.
 --convertEmptyValues      -e  Set to true if you would like the document client to convert empty values (0-length strings, binary buffers, and sets) to be converted to NULL types when persisting to DynamoDB.
+--userStop       After starting dynamodb local and all migrations and seeding is completed (if set to run), process will stay open until user terminates runinng process. When terminate signal received, it will stop the database on the running port.
 ```
 
 All the above options can be added to serverless.yml to set default configuration: e.g.
@@ -75,6 +76,7 @@ custom:
       migrate: true
       seed: true
       convertEmptyValues: true
+      userStop: true
     # Uncomment only if you already have a DynamoDB running locally
     # noStart: true
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All CLI options are optional:
 --migrate                 -m  After starting DynamoDB local, create DynamoDB tables from the Serverless configuration.
 --seed                    -s  After starting and migrating dynamodb local, injects seed data into your tables. The --seed option determines which data categories to onload.
 --convertEmptyValues      -e  Set to true if you would like the document client to convert empty values (0-length strings, binary buffers, and sets) to be converted to NULL types when persisting to DynamoDB.
---userStop       After starting dynamodb local and all migrations and seeding is completed (if set to run), process will stay open until user terminates running process. When terminate signal received, it will stop the database on the running port.
+--pauseDbAfterSeeding     -p  After starting dynamodb local and all migrations and seeding is completed (if set to run), process will stay open until user terminates running process. When terminate signal received, it will stop the database on the running port.
 ```
 
 All the above options can be added to serverless.yml to set default configuration: e.g.
@@ -76,7 +76,7 @@ custom:
       migrate: true
       seed: true
       convertEmptyValues: true
-      userStop: true
+      pauseDbAfterSeeding: true
     # Uncomment only if you already have a DynamoDB running locally
     # noStart: true
 ```

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ class ServerlessDynamodbLocal {
                                 usage: "Set to true if you would like the document client to convert empty values (0-length strings, binary buffers, and sets) to be converted to NULL types when persisting to DynamoDB.",
                             },
                             userStop: {
-                                usage: 'After starting dynamodb local and all migrations and seeding is completed (if set to run), process will stay open until user terminates running process. When terminate signal received, it will stop the database on the running port.'
+                                usage: "After starting dynamodb local and all migrations and seeding is completed (if set to run), process will stay open until user terminates running process. When terminate signal received, it will stop the database on the running port."
                             }                            
                         }
                     },
@@ -263,7 +263,7 @@ class ServerlessDynamodbLocal {
           .then(() => options.seed && this.seedHandler())
           .then(() => {
               if (options.userStop) {
-                  this.serverlessLog("DynamoDB - Database is running. Waiting for user to stop...")
+                  this.serverlessLog("DynamoDB - Database is running. Waiting for user to stop...");
                 return BbPromise.resolve()
                 .then(() => this._listenForTermination())
                 .then(() => this.endHandler());
@@ -304,18 +304,18 @@ class ServerlessDynamodbLocal {
 
     _listenForTermination() {
         // SIGINT will be usually sent when user presses ctrl+c
-        const waitForSigInt = new Promise(resolve => {
-        process.on('SIGINT', () => resolve('SIGINT'));
+        const waitForSigInt = new Promise((resolve) => {
+        process.on("SIGINT", () => resolve("SIGINT"));
         });
 
         // SIGTERM is a default termination signal in many cases,
         // for example when "killing" a subprocess spawned in node
         // with child_process methods
-        const waitForSigTerm = new Promise(resolve => {
-        process.on('SIGTERM', () => resolve('SIGTERM'));
+        const waitForSigTerm = new Promise((resolve) => {
+        process.on("SIGTERM", () => resolve("SIGTERM"));
         });
 
-        return Promise.race([waitForSigInt, waitForSigTerm]).then(command => {
+        return Promise.race([waitForSigInt, waitForSigTerm]).then((command) => {
         this.serverlessLog(`Got ${command} signal. Will stop dynamodb local...`);
         });
     }    

--- a/index.js
+++ b/index.js
@@ -265,7 +265,7 @@ class ServerlessDynamodbLocal {
               if (options.pauseDbAfterSeeding) {
                   this.serverlessLog("DynamoDB - Database is running. Waiting for user to stop...");
                 return BbPromise.resolve()
-                .then(() => this._listenForTermination())
+                .then(() => this.listenForTermination())
                 .then(() => this.endHandler());
               }
           });
@@ -302,7 +302,7 @@ class ServerlessDynamodbLocal {
         }).filter((n) => n);
     }
 
-    _listenForTermination() {
+    listenForTermination() {
         // SIGINT will be usually sent when user presses ctrl+c
         const waitForSigInt = new Promise((resolve) => {
         process.on("SIGINT", () => resolve("SIGINT"));

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ class ServerlessDynamodbLocal {
                                 shortcut: "e",
                                 usage: "Set to true if you would like the document client to convert empty values (0-length strings, binary buffers, and sets) to be converted to NULL types when persisting to DynamoDB.",
                             },
-                            userStop: {
+                            pauseDbAfterSeeding: {
                                 usage: "After starting dynamodb local and all migrations and seeding is completed (if set to run), process will stay open until user terminates running process. When terminate signal received, it will stop the database on the running port."
                             }                            
                         }
@@ -262,7 +262,7 @@ class ServerlessDynamodbLocal {
           .then(() => options.migrate && this.migrateHandler())
           .then(() => options.seed && this.seedHandler())
           .then(() => {
-              if (options.userStop) {
+              if (options.pauseDbAfterSeeding) {
                   this.serverlessLog("DynamoDB - Database is running. Waiting for user to stop...");
                 return BbPromise.resolve()
                 .then(() => this._listenForTermination())

--- a/index.js
+++ b/index.js
@@ -89,8 +89,8 @@ class ServerlessDynamodbLocal {
                                 shortcut: "e",
                                 usage: "Set to true if you would like the document client to convert empty values (0-length strings, binary buffers, and sets) to be converted to NULL types when persisting to DynamoDB.",
                             },
-                            leaveOn: {
-                                usage: 'Keep the process running until user sends kill command. This will kill the process the database is running once user sends terminate.'
+                            userStop: {
+                                usage: 'After starting dynamodb local and all migrations and seeding is completed (if set to run), process will stay open until user terminates runinng process. When terminate signal received, it will stop the database on the running port.'
                             }                            
                         }
                     },
@@ -262,7 +262,8 @@ class ServerlessDynamodbLocal {
           .then(() => options.migrate && this.migrateHandler())
           .then(() => options.seed && this.seedHandler())
           .then(() => {
-              if (options.leaveOn) {
+              if (options.userStop) {
+                  this.serverlessLog("DynamoDB - Database is running. Waiting for user to stop...")
                 return BbPromise.resolve()
                 .then(() => this._listenForTermination())
                 .then(() => this.endHandler());

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ class ServerlessDynamodbLocal {
                                 usage: "Set to true if you would like the document client to convert empty values (0-length strings, binary buffers, and sets) to be converted to NULL types when persisting to DynamoDB.",
                             },
                             userStop: {
-                                usage: 'After starting dynamodb local and all migrations and seeding is completed (if set to run), process will stay open until user terminates runinng process. When terminate signal received, it will stop the database on the running port.'
+                                usage: 'After starting dynamodb local and all migrations and seeding is completed (if set to run), process will stay open until user terminates running process. When terminate signal received, it will stop the database on the running port.'
                             }                            
                         }
                     },


### PR DESCRIPTION
Adds options for user to provide flag to keep process running until user send terminate signal.

This allows for the serverless-dynamodb-local plugin to call the dynamodb-local 'stop' command and still have the db instance in memory and the associated port it should kill the database process on.