### PR TITLE
Allow variable resolving

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ class ServerlessDynamodbLocal {
         this.serverless = serverless;
         this.service = serverless.service;
         this.serverlessLog = serverless.cli.log.bind(serverless.cli);
-        this.config = this.service.custom && this.service.custom.dynamodb || {};
+
         this.options = _.merge({
           localPath: serverless.config && path.join(serverless.config.servicePath, '.dynamodb')
           },
@@ -153,9 +153,11 @@ class ServerlessDynamodbLocal {
      * @return {Boolean} if the handler can run for the provided stage
      */
     shouldExecute() {
-      if (this.config.stages && this.config.stages.includes(this.stage)) {
+      const config = this.service.custom && this.service.custom.dynamodb || {};
+      if (config.stages && config.stages.includes(this.stage)) {
         return true;
       }
+
       return false;
     }
 


### PR DESCRIPTION
Fixes issue #[229]

Changes: 

Based on below this (section)[https://serverless.com/framework/docs/providers/aws/guide/plugins#serverless-instance], which is: 

```
Note: Variable references in the serverless instance are not resolved before a Plugin's constructor is called, so if you need these, make sure to wait to access those from your hooks.
```

So I moved the calls to this.config to the function they need them

Demo Link: No demo

Screenshots for the change: check the changes tab in the pull request
