### PR TITLE
#234 - Not able to specify DynamoDb host

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ class ServerlessDynamodbLocal {
                                 shortcut: "p",
                                 usage: "The port number that DynamoDB will use to communicate with your application. If you do not specify this option, the default port is 8000"
                             },
+                            host: {
+                               
+                                usage: "The host that DynamoDB will use to communicate with your application. If you do not specify this option, the default is localhost"
+                            },                            
                             cors: {
                                 shortcut: "c",
                                 usage: "Enable CORS support (cross-origin resource sharing) for JavaScript. You must provide a comma-separated \"allow\" list of specific domains. The default setting for -cors is an asterisk (*), which allows public access."


### PR DESCRIPTION
Fixes issue #234

Changes: added host as option

Demo Link: none

Screenshots for the change:  
