### PR TITLE
Don't ignore --port and --host CLI options for migrations after `start`

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ class ServerlessDynamodbLocal {
                                 shortcut: "p",
                                 usage: "The port number that DynamoDB will use to communicate with your application. If you do not specify this option, the default port is 8000"
                             },
+                            host: {
+                                shortcut: "h",
+                                usage: "The host name that DynamoDB will use to communicate with your application. If you do not specify this option, the default host name is 'localhost'"
+                            },
                             cors: {
                                 shortcut: "c",
                                 usage: "Enable CORS support (cross-origin resource sharing) for JavaScript. You must provide a comma-separated \"allow\" list of specific domains. The default setting for -cors is an asterisk (*), which allows public access."
@@ -127,15 +131,25 @@ class ServerlessDynamodbLocal {
     }
 
     get port() {
-        const config = this.service.custom && this.service.custom.dynamodb || {};
-        const port = _.get(config, "start.port", 8000);
-        return port;
+      const config = this.service.custom && this.service.custom.dynamodb || {};
+      const options = _.merge(
+        {},
+        config.start,
+        this.options
+      );
+      const port = options["port"] || 8000;
+      return port;
     }
 
     get host() {
-        const config = this.service.custom && this.service.custom.dynamodb || {};
-        const host = _.get(config, "start.host", "localhost");
-        return host;
+      const config = this.service.custom && this.service.custom.dynamodb || {};
+      const options = _.merge(
+        {},
+        config.start,
+        this.options
+      );
+      const host = options["host"] || "localhost";
+      return host;
     }
 
     /**

--- a/test/cliTest.js
+++ b/test/cliTest.js
@@ -1,0 +1,30 @@
+"use strict";
+//Define the modules required to mocha testing
+const assert = require("chai").assert;
+const http = require ("http");
+const expect = require("chai").expect;
+const should = require("should");
+const aws = require ("aws-sdk");
+const seeder = require("../src/seeder.js");
+const Plugin = require("../index.js");
+
+const serverlessMock = require("./serverlessMock");
+
+describe("command line options",function(){
+  describe("for 'start' command",function(){
+    let service;
+    before(function(){
+      this.timeout(60000);
+      service = new Plugin(serverlessMock, { port: 8123, host: "home.local" });
+      //return service.startHandler();
+    });
+
+    it(".port should return cli option",function(){
+      assert.equal(service.port, 8123);
+    });
+    
+    it(".host should return cli option",function(){
+      assert.equal(service.host, "home.local");
+    });
+  });
+});


### PR DESCRIPTION
Fixes issue where passing `--port` on command line for `start` subcommand was used when starting the server, but not for migrating.
This also adds the `--host` argument and fixes the same problem with it.

### Reproduce:
Given a serverless.yml like this:
```
service: sls-dynamodb-test

provider:
  name: aws
  runtime: nodejs10.x

functions:
  hello:
    handler: handler.hello

plugins:
  - serverless-dynamodb-local

custom:
  dynamodb:
    stages:
      - dev

resources:
  Resources:
    DynamodbTable:
      Type: "AWS::DynamoDB::Table"
      Properties:
        TableName: test-table
        AttributeDefinitions:
          - AttributeName: testId
            AttributeType: S
        KeySchema:
          - AttributeName: testId
            KeyType: HASH
        ProvisionedThroughput:
          ReadCapacityUnits: 1
          WriteCapacityUnits: 1
```
If you run:  
`sls dynamodb start --port 8123 --inMemory --migrate`

You will get the following error (the server is started, but migrating fails):
```
Dynamodb Local Started, Visit: http://localhost:8123/shell
NetworkingError: connect ECONNREFUSED 127.0.0.1:8000: DynamoDB - Error -

  Networking Error ---------------------------------------

  NetworkingError: connect ECONNREFUSED 127.0.0.1:8000
      at Object._errnoException (util.js:1022:11)
      at _exceptionWithHostPort (util.js:1044:20)
      at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1198:14)
  From previous event:
      at PluginManager.invoke (/Users/dean.holdren/.nvm/versions/node/v8.10.0/lib/node_modules/serverless/lib/classes/PluginManager.js:505:22)
      at getHooks.reduce.then (/Users/dean.holdren/.nvm/versions/node/v8.10.0/lib/node_modules/serverless/lib/classes/PluginManager.js:540:24)
  From previous event:
      at PluginManager.run (/Users/dean.holdren/.nvm/versions/node/v8.10.0/lib/node_modules/serverless/lib/classes/PluginManager.js:540:8)
      at variables.populateService.then (/Users/dean.holdren/.nvm/versions/node/v8.10.0/lib/node_modules/serverless/lib/Serverless.js:115:33)
      at runCallback (timers.js:794:20)
      at tryOnImmediate (timers.js:752:5)
      at processImmediate [as _immediateCallback] (timers.js:729:5)
  From previous event:
      at Serverless.run (/Users/dean.holdren/.nvm/versions/node/v8.10.0/lib/node_modules/serverless/lib/Serverless.js:102:74)
      at serverless.init.then (/Users/dean.holdren/.nvm/versions/node/v8.10.0/lib/node_modules/serverless/bin/serverless.js:72:30)
      at /Users/dean.holdren/.nvm/versions/node/v8.10.0/lib/node_modules/serverless/node_modules/graceful-fs/graceful-fs.js:111:16
      at /Users/dean.holdren/.nvm/versions/node/v8.10.0/lib/node_modules/serverless/node_modules/graceful-fs/graceful-fs.js:45:10
      at FSReqWrap.oncomplete (fs.js:135:15)
  From previous event:
      at initializeErrorReporter.then (/Users/dean.holdren/.nvm/versions/node/v8.10.0/lib/node_modules/serverless/bin/serverless.js:72:8)
      at runCallback (timers.js:794:20)
      at tryOnImmediate (timers.js:752:5)
      at processImmediate [as _immediateCallback] (timers.js:729:5)
  From previous event:
      at Object.<anonymous> (/Users/dean.holdren/.nvm/versions/node/v8.10.0/lib/node_modules/serverless/bin/serverless.js:57:4)
      at Module._compile (module.js:652:30)
      at Object.Module._extensions..js (module.js:663:10)
      at Module.load (module.js:565:32)
      at tryModuleLoad (module.js:505:12)
      at Function.Module._load (module.js:497:3)
      at Function.Module.runMain (module.js:693:10)
      at startup (bootstrap_node.js:188:16)
      at bootstrap_node.js:609:3

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com

  Your Environment Information ---------------------------
     Operating System:          darwin
     Node Version:              8.10.0
     Framework Version:         1.54.0
     Plugin Version:            3.1.2
     SDK Version:               2.1.2
     Components Core Version:   1.1.1
     Components CLI Version:    1.2.3
```

### Changes: 
modified the `get port()` and `get host()` methods to allow command line arguments to override serverless.yml configuration and defaults.
