### PR TITLE
Allow start hook configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ plugins:
   - serverless-offline #serverless-offline needs to be last in the list
 ```
 
+### Using with other local servers ###
+
+You can configure a start hook to match your local serverless plugin. For example, with `serverless-wsgi`:
+```yaml
+custom:
+  dynamodb:
+    start:
+      hook: before:wsgi:serve:serve
+```
+
 ## Reference Project
 * [serverless-react-boilerplate](https://github.com/99xt/serverless-react-boilerplate)
 

--- a/index.js
+++ b/index.js
@@ -124,6 +124,10 @@ class ServerlessDynamodbLocal {
             "before:offline:start:init": this.startHandler.bind(this),
             "before:offline:start:end": this.endHandler.bind(this),
         };
+
+        if (_.get(this.config, "start.hook")) {
+            this.hooks[_.get(this.config, "start.hook")] = this.startHandler.bind(this);
+        }
     }
 
     get port() {


### PR DESCRIPTION
This adds an option to define a manual hook so that dynamodb local starts with the dev server. In my case it allows `sls wsgi serve` to start it. I.e. [serverless-wsgi](https://github.com/logandk/serverless-wsgi).

I could just add the hook to the list instead if that's preferred, but it seems likely there are others that people might want to use this with.