### PR TITLE
Add host parameter to documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ custom:
     stages:
       - dev
     start:
+      host: localhost # localhost by default, but you can specify any host
       port: 8000
       inMemory: true
       heapInitial: 200m


### PR DESCRIPTION
Changes: add host parameter to documentation example in README.md

Demo Link: https://github.com/AlexHladin/serverless-dynamodb-local/tree/update-documentation

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/7945837/136835450-dcd176ae-d41a-46c3-b04a-9f74dca9a5c8.png)

