### PR TITLE
Remove hardcoded region for local use

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,7 +189,6 @@ class ServerlessDynamodbLocal {
         } else {
             dynamoOptions = {
                 endpoint: `http://${this.host}:${this.port}`,
-                region: "localhost",
                 accessKeyId: "MOCK_ACCESS_KEY_ID",
                 secretAccessKey: "MOCK_SECRET_ACCESS_KEY",
                 convertEmptyValues: options && options.convertEmptyValues ? options.convertEmptyValues : false,


### PR DESCRIPTION
Fixes issue #284

Changes: Remove hardcoded region for local use in dynamodb init
