### PR TITLE
Invalid AWS Mock Access Key ID through a new AWS-SDK version

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,8 +190,8 @@ class ServerlessDynamodbLocal {
             dynamoOptions = {
                 endpoint: `http://${this.host}:${this.port}`,
                 region: "localhost",
-                accessKeyId: "MOCK_ACCESS_KEY_ID",
-                secretAccessKey: "MOCK_SECRET_ACCESS_KEY",
+                accessKeyId: "MOCKACCESSKEYID",
+                secretAccessKey: "MOCKSECRETACCESSKEY",
                 convertEmptyValues: options && options.convertEmptyValues ? options.convertEmptyValues : false,
             };
         }


### PR DESCRIPTION
Due to a new AWS_SDK version only the following ACCESS KEY ID and SECRETS are allowed:

` DynamoDB local version 2.0.0 and greater AWS_ACCESS_KEY_ID can contain the only letters (A–Z, a–z) and numbers (0–9).`

[Stackoverflow thread](https://stackoverflow.com/questions/76592141/aws-js-sdk-suddenly-throws-the-access-key-id-or-security-token-is-invalid)