### PR TITLE
Add `--localPath` arugment to the `start` command.

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,6 +102,10 @@ class ServerlessDynamodbLocal {
                                 shortcut: "e",
                                 usage: "Set to true if you would like the document client to convert empty values (0-length strings, binary buffers, and sets) to be converted to NULL types when persisting to DynamoDB.",
                                 type: "boolean"
+                            },
+                            localPath: {
+                                usage: "Set the path to the DDB Local installation.",
+                                type: "string"
                             }
                         }
                     },


### PR DESCRIPTION
Changes: Adding `localPath` option to the `start` command.
It seems like there's an option for it with the `install` command - but without a corresponding argument in `start`, that's effectively useless.